### PR TITLE
Update Downloader.php

### DIFF
--- a/lib/Downloader.php
+++ b/lib/Downloader.php
@@ -193,6 +193,7 @@ class Downloader
 		$cmd .= " ".escapeshellarg($url);
 		
 		$cmd .= " --restrict-filenames"; // --restrict-filenames is for specials chars
+		$cmd .= " " . $this->get_post_processor();
 		$cmd .= " > /dev/null & echo $!";
 	
 		shell_exec($cmd);


### PR DESCRIPTION
Integration of post_processor option with youtube-dl options.
This patch uses post_processor option to send --prefer-avconv or --prefer-ffmpeg option to youtube-dl.
This patch may fix #7 (not tested).